### PR TITLE
Memory leaks and unecessary allocations

### DIFF
--- a/include/sort-algos-int-with-func/sort-test.c
+++ b/include/sort-algos-int-with-func/sort-test.c
@@ -36,6 +36,6 @@ void sort_test(
         printf("Unsuccessfully.\n\n");
     }
 
-		free(sort_data);
-		free(start_point);
+    free(sort_data);
+    free(start_point);
 }

--- a/include/sort-algos-int-with-func/sort-test.c
+++ b/include/sort-algos-int-with-func/sort-test.c
@@ -35,4 +35,7 @@ void sort_test(
     } else {
         printf("Unsuccessfully.\n\n");
     }
+
+		free(sort_data);
+		free(start_point);
 }

--- a/include/sort-algos-int/sort-test.c
+++ b/include/sort-algos-int/sort-test.c
@@ -33,4 +33,7 @@ void sort_test(
     } else {
         printf("Unsuccessfully.\n\n");
     }
+
+		free(sort_data);
+		free(start_point);
 }

--- a/include/sort-algos-int/sort-test.c
+++ b/include/sort-algos-int/sort-test.c
@@ -34,6 +34,6 @@ void sort_test(
         printf("Unsuccessfully.\n\n");
     }
 
-		free(sort_data);
-		free(start_point);
+    free(sort_data);
+    free(start_point);
 }

--- a/include/sort-algos/quick-sort.c
+++ b/include/sort-algos/quick-sort.c
@@ -12,8 +12,7 @@ void quick_sort(void *data_start, void *data_end, size_t item_size,
                 bool (*cmp_func)(const void *, const void *)) {
     if (data_start >= data_end - item_size)
         return;
-    void *mid = (void *) malloc(sizeof(void) * item_size);
-    memcpy(mid, data_end - item_size, item_size);
+    void *mid = data_end - item_size;
     void *left = data_start;
     void *right = data_end - item_size - item_size;
 

--- a/include/sort-algos/sort-test.c
+++ b/include/sort-algos/sort-test.c
@@ -34,4 +34,7 @@ void sort_test(
     } else {
         printf("Unsuccessfully.\n\n");
     }
+
+		free(sort_data);
+		free(start_point);
 }

--- a/include/sort-algos/sort-test.c
+++ b/include/sort-algos/sort-test.c
@@ -35,6 +35,6 @@ void sort_test(
         printf("Unsuccessfully.\n\n");
     }
 
-		free(sort_data);
-		free(start_point);
+    free(sort_data);
+    free(start_point);
 }

--- a/include/sorted-assert.c
+++ b/include/sorted-assert.c
@@ -53,5 +53,7 @@ bool sorted_assert(
         }
         cursor += item_size;
     }
+
+		free(used);
     return true;
 }

--- a/include/sorted-assert.c
+++ b/include/sorted-assert.c
@@ -54,6 +54,6 @@ bool sorted_assert(
         cursor += item_size;
     }
 
-		free(used);
+    free(used);
     return true;
 }


### PR DESCRIPTION
Added some free's to make sure that all memory allocated is released before it goes out of scope in 3 different cases:

- In the sort_test functions, a copy of the data is made and then subsequently sorted by one of the algorithms and checked, but the copied data is not freed and goes out of scope.
- Also in the sort_test functions, the timeval struct returned by the create_start_point() library function is dynamically allocated and the caller must free it, which was not happening before.
- In the sort_assert function, the boolean array, which is used to check if the data in the unsorted array and in the sorted array is the same, also went out of scope.

In the generic quicksort function, there was a dynamic allocation on each function call to copy the pivot and that copy would also go out of scope. However instead of freeing it, the copy was replaced by a memory reference since it was unnecessary.